### PR TITLE
Fix possible NullReferenceException in ArucoCharucoBoardTracker

### DIFF
--- a/Assets/ArucoUnity/Scripts/Objects/Trackers/ArucoCharucoBoardTracker.cs
+++ b/Assets/ArucoUnity/Scripts/Objects/Trackers/ArucoCharucoBoardTracker.cs
@@ -52,7 +52,7 @@ namespace ArucoUnity.Objects.Trackers
 
       foreach (var arucoCharucoBoard in arucoTracker.GetArucoObjects<ArucoCharucoBoard>(dictionary))
       {
-        if (arucoCharucoBoard.DetectedIds.Size() > 0)
+        if (arucoCharucoBoard.DetectedIds != null && arucoCharucoBoard.DetectedIds.Size() > 0)
         {
           if (arucoTracker.DrawDetectedCharucoMarkers)
           {


### PR DESCRIPTION
Fix NullRefException preventing users from using charuco tracker and drawing debug shapes (e.g. drawing detected markers) at the same time

Maybe only present due to slow camera init.